### PR TITLE
fix bug, undefined behavior that resulted in segfault

### DIFF
--- a/Trec_eval_extension/trec_eval.c
+++ b/Trec_eval_extension/trec_eval.c
@@ -124,15 +124,15 @@ static char *usage = "Usage: trec_eval [-h] [-q] {-m measure}* trec_rel_file tre
    -m: calculate and print measures indicated by 'measure'\n\
        ('-m all_qrels' prints all qrels measures, '-m official' is default)\n";
 
-extern long te_num_trec_measures;
+extern int te_num_trec_measures;
 extern TREC_MEAS *te_trec_measures[];
-extern long te_num_trec_measure_nicknames;
+extern int te_num_trec_measure_nicknames;
 extern TREC_MEASURE_NICKNAMES te_trec_measure_nicknames[];
-extern long te_num_rel_info_format;
+extern int te_num_rel_info_format;
 extern REL_INFO_FILE_FORMAT te_rel_info_format[];
-extern long te_num_results_format;
+extern int te_num_results_format;
 extern RESULTS_FILE_FORMAT te_results_format[];
-extern long te_num_form_inter_procs;
+extern int te_num_form_inter_procs;
 extern RESULTS_FILE_FORMAT te_form_inter_procs[];
 
 static int mark_measure (EPI *epi, char *optarg);


### PR DESCRIPTION
Declaring external int variable as a long results in undefined GCC behavior. This resulted in a segmentation fault when using this variable for a comparison.

Details: size variables are defined as ints:
https://github.com/trec-health-misinfo/Trec_eval_extension/blob/2d4e34c2b4a5d6f0f049ff9296f9b6060c39ba2e/Trec_eval_extension/measures.c#L184
but they were imported as longs:
https://github.com/trec-health-misinfo/Trec_eval_extension/blob/2d4e34c2b4a5d6f0f049ff9296f9b6060c39ba2e/Trec_eval_extension/trec_eval.c#L127

This is undefined behavior. GCC doesn't warn about it and nor does Valgrind, so it was a difficult bug to find. The bug resulted in non-ending loops like the one in
https://github.com/trec-health-misinfo/Trec_eval_extension/blob/2d4e34c2b4a5d6f0f049ff9296f9b6060c39ba2e/Trec_eval_extension/trec_eval.c#L349
which in turn resulted in a segmentation fault. 

This was already pointed out in  https://github.com/lcschv/Trec_eval_extension/issues/2 , but the root cause of the bug was not found. Looks like older versions of GCC dealt "in the right way" with this undefined behavior.